### PR TITLE
Remove backward incompatible properties

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -358,6 +358,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.keita.oouchi.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -373,6 +374,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.keita.oouchi.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/Example/AVDebugger.swift
+++ b/Example/Example/AVDebugger.swift
@@ -134,10 +134,6 @@ struct AVDebugger {
       logger.debug("[AVPlayerLayer][player]: \(String(describing: player))")
     }).disposed(by: self.disposeBag)
 
-    layer.rx.videoGravity.subscribe(onNext: { videoGravity in
-      logger.debug("[AVPlayerLayer][videoGravity]: \(videoGravity)")
-    }).disposed(by: self.disposeBag)
-
     layer.rx.readyForDisplay.subscribe(onNext: { readyForDisplay in
       logger.debug("[AVPlayerLayer][readyForDisplay]: \(readyForDisplay)")
     }).disposed(by: self.disposeBag)
@@ -145,16 +141,9 @@ struct AVDebugger {
     layer.rx.videoRect.subscribe(onNext: { videoRect in
       logger.debug("[AVPlayerLayer][videoRect]: \(videoRect)")
     }).disposed(by: self.disposeBag)
-
-    layer.rx.videoGravity.subscribe(onNext: { gravity in
-      logger.debug("[AVPlayerLayer][videoGravity]: \(gravity)")
-    }).disposed(by: self.disposeBag)
   }
 
   func debug(track: AVAssetTrack) {
-    track.rx.mediaType.subscribe(onSuccess: { mediaType in
-      logger.debug("[AVAssetTrack][mediaType]: \(String(describing: mediaType))")
-    }).disposed(by: self.disposeBag)
 
     track.rx.playable.subscribe(onSuccess: { playable in
       logger.debug("[AVAssetTrack][playable]: \(playable)")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 | Target            | Version |
 |-------------------|---------|
-| iOS               |  => 9.0 |
+| iOS               |  => 10.0 |
 | Swift             |  ~> 4.0 |
 | RxSwift / RxCocoa |  ~> 4.0 |
 

--- a/RxAudioVisual.podspec
+++ b/RxAudioVisual.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source        = { :git => "https://github.com/keitaoouchi/RxAudioVisual.git", :tag => "#{s.version}" }
   s.source_files  = "RxAudioVisual/*.{swift,h}"
   s.frameworks    = "AVFoundation"
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "10.0"
   s.pod_target_xcconfig = { "SWIFT_VERSION" => "4.0" }
   s.dependency 'RxSwift', '~> 4.0'
   s.dependency 'RxCocoa', '~> 4.0'

--- a/RxAudioVisual/AVAssetTrack+Rx.swift
+++ b/RxAudioVisual/AVAssetTrack+Rx.swift
@@ -3,17 +3,19 @@ import RxSwift
 
 extension Reactive where Base: AVAssetTrack {
 
-  public var mediaType: Single<String?> {
-    return self
-        .loadAsync(for: "mediaType")
-        .map({ loaded in
-          if loaded {
-            return self.base.mediaType
-          } else {
-            return nil
-          }
-        })
-  }
+  // FIXME: ~ iOS10.0, this videoGravity returns String
+  //@available(iOS 11, *)
+  //public var mediaType: Single<String?> {
+  //  return self
+  //      .loadAsync(for: "mediaType")
+  //      .map({ loaded in
+  //        if loaded {
+  //          return self.base.mediaType
+  //        } else {
+  //          return nil
+  //        }
+  //      })
+  //}
 
   public var playable: Single<Bool> {
     return self

--- a/RxAudioVisual/AVPlayerLayer+Rx.swift
+++ b/RxAudioVisual/AVPlayerLayer+Rx.swift
@@ -10,11 +10,13 @@ extension Reactive where Base: AVPlayerLayer {
       .observe(AVPlayer.self, #keyPath(AVPlayerLayer.player))
   }
 
-  public var videoGravity: Observable<String> {
-    return self
-      .observe(String.self, #keyPath(AVPlayerLayer.videoGravity))
-      .map { $0 ?? AVLayerVideoGravityResizeAspect }
-  }
+  // FIXME: ~ iOS10.0, this videoGravity returns String
+  //@available(iOS 11, *)
+  //public var videoGravity: Observable<AVLayerVideoGravity> {
+  //  return self
+  //    .observe(AVLayerVideoGravity.self, #keyPath(AVPlayerLayer.videoGravity))
+  //    .map { $0 ?? AVLayerVideoGravity.reizeAspect }
+  //}
 
   public var readyForDisplay: Observable<Bool> {
     return self

--- a/RxAudioVisualTests/AVPlayerLayer+RxSpec.swift
+++ b/RxAudioVisualTests/AVPlayerLayer+RxSpec.swift
@@ -34,12 +34,12 @@ class AVPlayerLayerSpec: QuickSpec {
         expect(e).toEventually(equal(player))
       }
 
-      it("should load videoGravity") {
-        var e: String?
-        playerLayer.rx.videoGravity.subscribe(onNext: { v in e = v }).addDisposableTo(disposeBag)
-        expect(e).toEventuallyNot(beNil())
-        expect(e).toEventually(equal(AVLayerVideoGravityResizeAspect))
-      }
+      // it("should load videoGravity") {
+      //   var e: String?
+      //   playerLayer.rx.videoGravity.subscribe(onNext: { v in e = v }).addDisposableTo(disposeBag)
+      //   expect(e).toEventuallyNot(beNil())
+      //   expect(e).toEventually(equal(AVLayerVideoGravityResizeAspect))
+      // }
 
       it("should load readyForDisplay") {
         var e: Bool?


### PR DESCRIPTION
Removed `AVAssetTrack.mediaType` and `AVPlayerLayer.videoGravity`

#### [AVAssetTrack](https://developer.apple.com/documentation/avfoundation/avassettrack?changes=latest_minor)

- mediaType: `String` --> `AVMediaType`

#### [AVPlayerLayer](https://developer.apple.com/documentation/avfoundation/avplayerlayer?changes=latest_minor)

- videoGravity: `String` --> `AVLayerVideoGravity`